### PR TITLE
Restrict middleware to url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want to see how use this module with Fastify, check [here](https://github
 ```
 npm install middie --save
 ```
-
+<a name="usage"></a>
 ## Usage
 ```js
 const Middie = require('middie')
@@ -42,9 +42,25 @@ function _runMiddlewares (err, req, res) {
 }
 ```
 
+<a name="restrict-usage"></a>
+#### Restrict middleware execution to a certain path(s)
+If you need to run a middleware only under certains path(s), just pass the path as first parameter to `use` and you are done!  
+*Note that this does not support routes with parameters, (eg: `/user/:id/comments`)*
+```js
+// Single path
+middie.use('/public', staticFiles('/assets'))
+
+// Multiple paths
+middie.use(['/public', '/dist'], staticFiles('/assets'))
+
+```
+
 ## Acknowledgements
 
-This project was kindly sponsored by [nearForm](http://nearform.com).
+This project is kindly sponsored by:
+- [nearForm](http://nearform.com)
+- [LetzDoIt](http://www.letzdoitapp.com/)
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
+    "pathname-match": "^1.2.0",
     "reusify": "^1.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -13,7 +13,9 @@ test('use no function', t => {
     t.equal(b, res)
   })
 
-  const req = {}
+  const req = {
+    url: '/test'
+  }
   const res = {}
 
   instance.run(req, res)
@@ -27,7 +29,9 @@ test('use a function', t => {
     t.equal(a, req)
     t.equal(b, res)
   })
-  const req = {}
+  const req = {
+    url: '/test'
+  }
   const res = {}
 
   t.equal(instance.use(function (req, res, next) {
@@ -46,7 +50,9 @@ test('use two functions', t => {
     t.equal(a, req)
     t.equal(b, res)
   })
-  const req = {}
+  const req = {
+    url: '/test'
+  }
   const res = {}
   var counter = 0
 
@@ -67,7 +73,9 @@ test('stop the middleware chain if one errors', t => {
   const instance = middie(function (err, a, b) {
     t.ok(err, 'error is forwarded')
   })
-  const req = {}
+  const req = {
+    url: '/test'
+  }
   const res = {}
 
   instance.use(function (req, res, next) {
@@ -76,6 +84,92 @@ test('stop the middleware chain if one errors', t => {
     t.fail('this should never be called')
     next()
   })
+
+  instance.run(req, res)
+})
+
+test('run restricted by path', t => {
+  t.plan(9)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/test', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/test'
+  }
+  const res = {}
+
+  t.equal(instance.use(function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/test', function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/no-call', function (req, res, next) {
+    t.fail('should not call this function')
+    next()
+  }), instance)
+
+  instance.run(req, res)
+})
+
+test('run restricted by array path', t => {
+  t.plan(9)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/test', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/test'
+  }
+  const res = {}
+
+  t.equal(instance.use(function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use(['/test', '/other-path'], function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use(['/no-call', 'other-path'], function (req, res, next) {
+    t.fail('should not call this function')
+    next()
+  }), instance)
+
+  instance.run(req, res)
+})
+
+test('Should strip the url to only match the pathname', t => {
+  t.plan(6)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/test#foo?bin=baz', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/test#foo?bin=baz'
+  }
+  const res = {}
+
+  t.equal(instance.use('/test', function (req, res, next) {
+    t.pass('function called')
+    next()
+  }), instance)
 
   instance.run(req, res)
 })


### PR DESCRIPTION
As titled, see #1 and https://github.com/fastify/fastify/issues/55 to know more.

This a very easy implementation, it does not support url with parameters (eg: `user/:id/comments`).
The api can accept a single string or and array of strings, this does not introduce a breaking change and leaves space to extend the url support in the future.
I didn't run the benchmarks to see if there are some differences, but I think not.

Example:
```js
middie.use('/test', function (req, res, next) {
  next()
})
```

Feedbacks?
cc @mcollina @cedmax