### PR TITLE
Match start with path (*)

### DIFF
--- a/middie.js
+++ b/middie.js
@@ -2,6 +2,7 @@
 
 const reusify = require('reusify')
 const pathMatch = require('pathname-match')
+const endOfPathAsterixRegex = /\/\*$/
 
 function middie (complete) {
   var functions = []
@@ -61,10 +62,16 @@ function middie (complete) {
       } else {
         if (!urls[i]) {
           functions[i](req, res, that.done)
-        } else if (urls[i] && (urls[i] === url || urls[i].indexOf(url) > -1)) {
-          functions[i](req, res, that.done)
         } else {
-          that.done()
+          if (urls[i] === url) {
+            functions[i](req, res, that.done)
+          } else if (typeof urls[i] !== 'string' && urls[i].indexOf(url) > -1) {
+            functions[i](req, res, that.done)
+          } else if (endOfPathAsterixRegex.test(urls[i]) && url.indexOf(urls[i].slice(0, -1)) > -1) {
+            functions[i](req, res, that.done)
+          } else {
+            that.done()
+          }
         }
       }
     }

--- a/middie.js
+++ b/middie.js
@@ -61,12 +61,13 @@ function middie (complete) {
         that.i = 0
         pool.release(that)
       } else {
+        const fn = urls[i].fn
         if (!urls[i].path) {
-          urls[i].fn(req, res, that.done)
+          fn(req, res, that.done)
         } else if (urls[i].wildcard && pathMatchWildcard(url, urls[i].path)) {
-          urls[i].fn(req, res, that.done)
+          fn(req, res, that.done)
         } else if (urls[i].path === url || (typeof urls[i].path !== 'string' && urls[i].path.indexOf(url) > -1)) {
-          urls[i].fn(req, res, that.done)
+          fn(req, res, that.done)
         } else {
           that.done()
         }

--- a/test.js
+++ b/test.js
@@ -120,6 +120,38 @@ test('run restricted by path', t => {
   instance.run(req, res)
 })
 
+test('run restricted by path with * at the end', t => {
+  t.plan(8)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/test/aaa/bbb', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/test/aaa/bbb'
+  }
+  const res = {}
+
+  t.equal(instance.use('/test/*', function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/test/aaa/bbb/*', function (req, res, next) {
+    t.fail('should not call this function')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/test/aaa*', function (req, res, next) {
+    t.fail('should not call this function')
+    next()
+  }), instance)
+
+  instance.run(req, res)
+})
+
 test('run restricted by array path', t => {
   t.plan(9)
 


### PR DESCRIPTION
Help using fastify middleware when you want to match multiple routes with same starting url.

Needed it to switch from express : 

```js
router.all('/api/*', yourMiddleware);
```

to 

```js
fastify.use('/api/*', yourMiddleware);
```
