### PR TITLE
Should match all chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jspm_packages
 
 # vim swap files
 *.swp
+
+# package lock
+package-lock.json

--- a/middie.js
+++ b/middie.js
@@ -20,7 +20,7 @@ function middie (complete) {
 
     var regexp
     if (url) {
-      regexp = pathToRegexp(url, [], {
+      regexp = pathToRegexp(sanitizePrefixUrl(url), [], {
         end: false,
         strict: false
       })
@@ -103,6 +103,13 @@ function sanitizeUrl (url) {
       return url.slice(0, i)
     }
   }
+  return url
+}
+
+function sanitizePrefixUrl (url) {
+  if (url === '') return url
+  if (url === '/') return ''
+  if (url[url.length - 1] === '/') return url.slice(0, -1)
   return url
 }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
-    "path-to-regexp": "^1.7.0",
+    "path-to-regexp": "^2.0.0",
     "reusify": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
-    "path-to-regexp": "^0.1.7",
+    "path-to-regexp": "^1.7.0",
     "reusify": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "x-xss-protection": "^1.0.0"
   },
   "dependencies": {
-    "path-to-regexp": "^2.0.0",
+    "path-to-regexp": "^0.1.7",
     "reusify": "^1.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -237,3 +237,48 @@ test('limit serve static to a specific folder', t => {
     })
   })
 })
+
+test('should match all chain', t => {
+  t.plan(2)
+  const instance = middie(function (err, req, res) {
+    t.error(err)
+    t.equal(req, {
+      url: '/inner/in/depth',
+      undefined: true,
+      null: true,
+      empty: true,
+      root: true,
+      inner: true,
+      innerSlashed: true,
+      innerIn: true,
+      innerInSlashed: true,
+      innerInDepth: true,
+      innerInDepthSlashed: true
+    })
+  })
+  const req = {
+    url: '/inner/in/depth'
+  }
+  const res = {}
+
+  const prefixes = [
+    { prefix: undefined, name: 'undefined' },
+    { prefix: null, name: 'undefined' },
+    { prefix: '', name: 'empty' },
+    { prefix: '/', name: 'root' },
+    { prefix: '/inner', name: 'inner' },
+    { prefix: '/inner/', name: 'innerSlashed' },
+    { prefix: '/inner/in', name: 'innerIn' },
+    { prefix: '/inner/in/', name: 'innerInSlashed' },
+    { prefix: '/inner/in/depth', name: 'innerInDepth' },
+    { prefix: '/inner/in/depth/', name: 'innerInDepthSlashed' }
+  ]
+  prefixes.forEach(function (o) {
+    instance.use(o.prefix, function (req, res, next) {
+      req[o.name] = true
+      next()
+    })
+  })
+
+  instance.run(req, res)
+})

--- a/test.js
+++ b/test.js
@@ -242,7 +242,7 @@ test('should match all chain', t => {
   t.plan(2)
   const instance = middie(function (err, req, res) {
     t.error(err)
-    t.equal(req, {
+    t.deepEqual(req, {
       url: '/inner/in/depth',
       undefined: true,
       null: true,
@@ -263,7 +263,7 @@ test('should match all chain', t => {
 
   const prefixes = [
     { prefix: undefined, name: 'undefined' },
-    { prefix: null, name: 'undefined' },
+    { prefix: null, name: 'null' },
     { prefix: '', name: 'empty' },
     { prefix: '/', name: 'root' },
     { prefix: '/inner', name: 'inner' },
@@ -275,6 +275,7 @@ test('should match all chain', t => {
   ]
   prefixes.forEach(function (o) {
     instance.use(o.prefix, function (req, res, next) {
+      if (req[o.name]) throw new Error('Called twice!')
       req[o.name] = true
       next()
     })


### PR DESCRIPTION
This PR aims to enlight the issue described at https://github.com/fastify/fastify/pull/295

The prefix `/` generates the regex `/^\/(?:\/(?=$))?(?=\/|$)/i`. The end of this regex `(?=\/|$)` doesn't match.

But I'm a regex expert