### PR TITLE
"/path/" should match "/path"?

### DIFF
--- a/test.js
+++ b/test.js
@@ -283,3 +283,29 @@ test('should match all chain', t => {
 
   instance.run(req, res)
 })
+
+test('should match the same slashed path', t => {
+  t.plan(3)
+  const instance = middie(function (err, req, res) {
+    t.error(err)
+    t.deepEqual(req, {
+      url: '/path'
+    })
+  })
+  const req = {
+    url: '/path'
+  }
+  const res = {}
+
+  instance.use('/path/', function (req, res, next) {
+    t.pass('function called')
+    next()
+  })
+
+  instance.use('/path/inner', function (req, res, next) {
+    t.fail()
+    next()
+  })
+
+  instance.run(req, res)
+})


### PR DESCRIPTION
A request with `/path` url matches this middleware
```js
middie.use('/path/', theHandler)
```

Is this right?

NB:
`express@4` and `express@5.0.0-alpha.6` allow the match
```js
'use strict'

const app = require('express')()

app.use('/path/', function (req, res, next) {
  console.log('HHHHHHHH')
  next()
})

app.listen(3000)
```

curling to `http://localhost:3000/path/` prints the log