### PR TITLE
Set `req.originalUrl` before running middleware

### DIFF
--- a/middie.js
+++ b/middie.js
@@ -39,11 +39,12 @@ function middie (complete) {
       return
     }
 
+    req.originalUrl = req.url
+
     var holder = pool.get()
     holder.req = req
     holder.res = res
     holder.url = sanitizeUrl(req.url)
-    holder.originalUrl = req.url
     holder.context = ctx
     holder.done()
   }
@@ -53,7 +54,6 @@ function middie (complete) {
     this.req = null
     this.res = null
     this.url = null
-    this.originalUrl = null
     this.context = null
     this.i = 0
 
@@ -65,7 +65,7 @@ function middie (complete) {
       var context = that.context
       var i = that.i++
 
-      req.url = that.originalUrl
+      req.url = req.originalUrl
 
       if (err || middlewares.length === i) {
         complete(err, req, res, context)

--- a/test.js
+++ b/test.js
@@ -198,6 +198,25 @@ test('should keep the context', t => {
   instance.run(req, res, { key: true })
 })
 
+test('should add `originalUrl` property to req', t => {
+  t.plan(2)
+
+  const instance = middie(function (err) {
+    t.error(err)
+  })
+  const req = {
+    url: '/test'
+  }
+  const res = {}
+
+  instance.use(function (req, res, next) {
+    t.equal(req.originalUrl, '/test')
+    next()
+  })
+
+  instance.run(req, res)
+})
+
 test('basic serve static', t => {
   const instance = middie(function () {
     t.fail('the default route should never be called')
@@ -244,6 +263,7 @@ test('should match all chain', t => {
     t.error(err)
     t.deepEqual(req, {
       url: '/inner/in/depth',
+      originalUrl: '/inner/in/depth',
       undefined: true,
       null: true,
       empty: true,
@@ -289,7 +309,8 @@ test('should match the same slashed path', t => {
   const instance = middie(function (err, req, res) {
     t.error(err)
     t.deepEqual(req, {
-      url: '/path'
+      url: '/path',
+      originalUrl: '/path'
     })
   })
   const req = {


### PR DESCRIPTION
For better compatibility with Express middleware.