### PR TITLE
Support adding an array of middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *middie* is the module that add middlewares support on steroids to [Fastify](https://www.npmjs.com/package/fastify).
 
-The syntax style is the same as [express](http://npm.im/express)/[connect](https://www.npmjs.com/package/connect).  
+The syntax style is the same as [express](http://npm.im/express)/[connect](https://www.npmjs.com/package/connect).
 Does not support the full syntax `middleware(err, req, res, next)`, because error handling is done inside Fastify.
 
 If you want to see how use this module with Fastify, check [here](https://github.com/fastify/fastify/#fastifyusemiddlewarereq-res-next).
@@ -67,7 +67,7 @@ function _runMiddlewares (err, req, res, ctx) {
 
 <a name="restrict-usage"></a>
 #### Restrict middleware execution to a certain path(s)
-If you need to run a middleware only under certains path(s), just pass the path as first parameter to `use` and you are done!  
+If you need to run a middleware only under certains path(s), just pass the path as first parameter to `use` and you are done!
 
 *Note that this does support routes with parameters, e.g. `/user/:id/comments`, but all the matched parameters will be discarded*
 
@@ -75,8 +75,14 @@ If you need to run a middleware only under certains path(s), just pass the path 
 // Single path
 middie.use('/public', staticFiles('/assets'))
 
+// Multiple middleware
+middie.use('/public', [cors(), staticFiles('/assets')])
+
 // Multiple paths
 middie.use(['/public', '/dist'], staticFiles('/assets'))
+
+// Multiple paths and multiple middleware
+middie.use(['/public', '/dist'], [cors(), staticFiles('/assets')])
 ```
 
 To guarantee compatibility with Express, adding a prefix uses [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) to compute

--- a/middie.js
+++ b/middie.js
@@ -26,11 +26,11 @@ function middie (complete) {
       })
     }
 
-    if (Object.prototype.toString.call(f) === '[object Array]') {
-      for (var i = 0, len = f.length; i < len; i++) {
+    if (Array.isArray(f)) {
+      for (var val of f) {
         middlewares.push({
           regexp,
-          fn: f[i]
+          fn: val
         })
       }
     } else {

--- a/middie.js
+++ b/middie.js
@@ -12,7 +12,12 @@ function middie (complete) {
     run
   }
 
-  function setMiddleware (url, f) {
+  function use (url, f) {
+    if (typeof f === 'undefined') {
+      f = url
+      url = null
+    }
+
     var regexp
     if (url) {
       regexp = pathToRegexp(sanitizePrefixUrl(url), [], {
@@ -21,24 +26,18 @@ function middie (complete) {
       })
     }
 
-    middlewares.push({
-      regexp,
-      fn: f
-    })
-  }
-
-  function use (url, f) {
-    if (typeof f === 'undefined') {
-      f = url
-      url = null
-    }
-
     if (Object.prototype.toString.call(f) === '[object Array]') {
       for (var i = 0, len = f.length; i < len; i++) {
-        setMiddleware(url, f[i])
+        middlewares.push({
+          regexp,
+          fn: f[i]
+        })
       }
     } else {
-      setMiddleware(url, f)
+      middlewares.push({
+        regexp,
+        fn: f
+      })
     }
 
     return this

--- a/middie.js
+++ b/middie.js
@@ -13,7 +13,7 @@ function middie (complete) {
   }
 
   function use (url, f) {
-    if (typeof f === 'undefined') {
+    if (f === undefined) {
       f = url
       url = null
     }

--- a/middie.js
+++ b/middie.js
@@ -12,12 +12,7 @@ function middie (complete) {
     run
   }
 
-  function use (url, f) {
-    if (typeof url === 'function') {
-      f = url
-      url = null
-    }
-
+  function setMiddleware (url, f) {
     var regexp
     if (url) {
       regexp = pathToRegexp(sanitizePrefixUrl(url), [], {
@@ -30,6 +25,22 @@ function middie (complete) {
       regexp,
       fn: f
     })
+  }
+
+  function use (url, f) {
+    if (typeof f === 'undefined') {
+      f = url
+      url = null
+    }
+
+    if (Object.prototype.toString.call(f) === '[object Array]') {
+      for (var i = 0, len = f.length; i < len; i++) {
+        setMiddleware(url, f[i])
+      }
+    } else {
+      setMiddleware(url, f)
+    }
+
     return this
   }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "middie.js",
   "scripts": {
     "test": "standard && tap test.js",
-    "coverage": "tap --cov --coverage-report=html test.js"
+    "coverage": "tap --cov --coverage-report=html test.js",
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "keywords": [
     "fastify",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "middie.js",
   "scripts": {
     "test": "standard && tap test.js",
-    "coverage": "tap --cov --coverage-report=html test.js",
-    "lint": "standard",
-    "lint:fix": "standard --fix"
+    "coverage": "tap --cov --coverage-report=html test.js"
   },
   "keywords": [
     "fastify",

--- a/test.js
+++ b/test.js
@@ -154,6 +154,72 @@ test('run restricted by array path', t => {
   instance.run(req, res)
 })
 
+test('run array of middleware restricted by path', t => {
+  t.plan(10)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/test', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/test'
+  }
+  const res = {}
+
+  t.equal(instance.use([function (req, res, next) {
+    t.ok('function called')
+    next()
+  }, function (req, res, next) {
+    t.ok('function called')
+    next()
+  }]), instance)
+
+  t.equal(instance.use('/test', [function (req, res, next) {
+    t.ok('function called')
+    next()
+  }, function (req, res, next) {
+    t.ok('function called')
+    next()
+  }]), instance)
+
+  instance.run(req, res)
+})
+
+test('run array of middleware restricted by array path', t => {
+  t.plan(10)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/test', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/test'
+  }
+  const res = {}
+
+  t.equal(instance.use([function (req, res, next) {
+    t.ok('function called')
+    next()
+  }, function (req, res, next) {
+    t.ok('function called')
+    next()
+  }]), instance)
+
+  t.equal(instance.use(['/test', '/other-path'], [function (req, res, next) {
+    t.ok('function called')
+    next()
+  }, function (req, res, next) {
+    t.ok('function called')
+    next()
+  }]), instance)
+
+  instance.run(req, res)
+})
+
 test('Should strip the url to only match the pathname', t => {
   t.plan(6)
 


### PR DESCRIPTION
This adds support for setting an array of middleware. This is a feature found in express.js it would be nice to replicate since it makes it easy to bundle middlewares (ex; helmet does now return an array of middlewares if one use the single helmet middleware).

In Fastify this will play out as follow:

```js
const middlewares = [
    (req, res, next) => {
        next();
    },
    (req, res, next) => {
        next();
    },
    (req, res, next) => {
        next();
    }
];
app.use(middlewares);
```

Original request issue: https://github.com/fastify/fastify/issues/1203