### PR TITLE
fix url replacement on middlewares restricted by path

### DIFF
--- a/middie.js
+++ b/middie.js
@@ -101,7 +101,7 @@ function middie (complete) {
           var result = regexp.exec(url)
           if (result) {
             req.url = req.url.replace(result[0], '')
-            if (!req.url.startsWith('/')) {
+            if (req.url.startsWith('/') === false) {
               req.url = '/' + req.url
             }
             fn(req, res, that.done)

--- a/middie.js
+++ b/middie.js
@@ -100,7 +100,10 @@ function middie (complete) {
         if (regexp) {
           var result = regexp.exec(url)
           if (result) {
-            req.url = req.url.replace(result[0], '/')
+            req.url = req.url.replace(result[0], '')
+            if (!req.url.startsWith('/')) {
+              req.url = '/' + req.url
+            }
             fn(req, res, that.done)
           } else {
             that.done()

--- a/test.js
+++ b/test.js
@@ -91,7 +91,7 @@ test('stop the middleware chain if one errors', t => {
 })
 
 test('run restricted by path', t => {
-  t.plan(9)
+  t.plan(11)
 
   const instance = middie(function (err, a, b) {
     t.error(err)
@@ -114,8 +114,45 @@ test('run restricted by path', t => {
     next()
   }), instance)
 
+  t.equal(instance.use('/test', function (req, res, next) {
+    t.equal('/', req.url)
+    next()
+  }), instance)
+
   t.equal(instance.use('/no-call', function (req, res, next) {
     t.fail('should not call this function')
+    next()
+  }), instance)
+
+  instance.run(req, res)
+})
+
+test('run restricted by path - prefix override', t => {
+  t.plan(10)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/test/other/one', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/test/other/one'
+  }
+  const res = {}
+
+  t.equal(instance.use(function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/test', function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/test', function (req, res, next) {
+    t.equal('/other/one', req.url)
     next()
   }), instance)
 

--- a/test.js
+++ b/test.js
@@ -159,6 +159,38 @@ test('run restricted by path - prefix override', t => {
   instance.run(req, res)
 })
 
+test('run restricted by path - prefix override 2', t => {
+  t.plan(10)
+
+  const instance = middie(function (err, a, b) {
+    t.error(err)
+    t.equal(a, req)
+    t.equal('/tasks-api/task', req.url)
+    t.equal(b, res)
+  })
+  const req = {
+    url: '/tasks-api/task'
+  }
+  const res = {}
+
+  t.equal(instance.use(function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/tasks-api', function (req, res, next) {
+    t.ok('function called')
+    next()
+  }), instance)
+
+  t.equal(instance.use('/tasks-api', function (req, res, next) {
+    t.equal('/task', req.url)
+    next()
+  }), instance)
+
+  instance.run(req, res)
+})
+
 test('run restricted by array path', t => {
   t.plan(9)
 


### PR DESCRIPTION
When the `req.url` is replaced like this: `req.url = req.url.replace(result[0], '/')`

Invalid urls appear on the middlewares, for example:
`/tasks-api/task` translates to `//task` for middlewares restricted to `/tasks-api`

This fix does `req.url` replacement correctly.