### PR TITLE
Add rudimentary TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
 import {FastifyPlugin} from 'fastify'
 
-declare const middlePlugin: FastifyPlugin
+// Middie doesn't have options yet
+export interface MiddiePluginOptions {
+}
 
-export = middlePlugin
+declare const middiePlugin: FastifyPlugin<MiddiePluginOptions>;
+export default middiePlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+import {FastifyPlugin} from 'fastify'
+
+declare const middlePlugin: FastifyPlugin
+
+export = middlePlugin

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.0",
   "description": "Middleware engine for Fastify",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "standard && tap --no-coverage test/*.test.js",
     "coverage": "tap --cov --coverage-report=html test.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "standard && tap --no-coverage test/*.test.js",
+    "test": "standard && tap --no-coverage test/*.test.js && tsd",
     "coverage": "tap --cov --coverage-report=html test.js"
   },
   "keywords": [
@@ -38,7 +38,9 @@
     "serve-static": "^1.14.1",
     "simple-get": "^3.1.0",
     "standard": "^14.3.1",
-    "tap": "^14.10.5"
+    "tap": "^14.10.5",
+    "tsd": "^0.11.0",
+    "typescript": "3.9.3"
   },
   "dependencies": {
     "fastify-plugin": "^2.0.0",
@@ -47,5 +49,8 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "tsd": {
+    "directory": "test"
   }
 }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,0 +1,8 @@
+import fastify from "fastify";
+import middiePlugin, {MiddiePluginOptions} from "..";
+import { expectAssignable } from "tsd";
+
+const app = fastify();
+app.register(middiePlugin);
+
+expectAssignable<MiddiePluginOptions>({})


### PR DESCRIPTION
This makes sure that ES6 TypeScript imports work properly for this package without complaining about types not being found.

Unfortunately, it does not address the elephant in the room of `use` being defined as `void` in original `fastify` definitions; however, TypeScript does not allow for type overriding, so I don't think that can be solved without changing `fastify` types.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
