### PR TITLE
fix: marking fastify as a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "path-to-regexp": "^6.1.0",
     "reusify": "^1.0.4"
   },
+  "peerDependencies": {
+    "fastify": "3.x"
+  },
   "engines": {
     "node": ">=10.0.0"
   },


### PR DESCRIPTION
- fastify/lib/symbols is referenced in index.js during runtime

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
