### PR TITLE
Allow access to the body and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ async function subsystem (fastify, opts) {
 
 If you want to change the Fastify hook that the middleware will be attached to, pass a `hook` option like so:
 
-*Note you can access `req.body` from the `preValidation` lifecycle step onwards. The lifecycle order is available in the (Fastify documentation)[https://www.fastify.io/docs/latest/Reference/Hooks/]*
+*Note you can access `req.body` from the `preValidation` lifecycle step onwards. Take a look at the [Lifecycle](https://www.fastify.io/docs/latest/Lifecycle/) documentation page to see the order of the steps.*
 
 ```js
 const fastify = require('fastify')()

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ async function subsystem (fastify, opts) {
 
 If you want to change the Fastify hook that the middleware will be attached to, pass a `hook` option like so:
 
+*Note you can access `req.body` from the `preValidation` lifecycle step onwards. The lifecycle order is available in the (Fastify documentation)[https://www.fastify.io/docs/latest/Reference/Hooks/]*
+
 ```js
 const fastify = require('fastify')()
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,15 @@
-import {NextHandleFunction, SimpleHandleFunction} from 'connect'
+import * as connect from 'connect'
 import {FastifyPluginCallback} from 'fastify'
+import * as http from "http";
+
+interface IncomingMessageExtended {
+  body?: any;
+  query?: any;
+}
+
+type NextFunction = (err?: any) => void;
+type SimpleHandleFunction = (req: http.IncomingMessage & IncomingMessageExtended, res: http.ServerResponse) => void;
+type NextHandleFunction = (req: connect.IncomingMessage & IncomingMessageExtended, res: http.ServerResponse, next: NextFunction) => void;
 
 type Handler = SimpleHandleFunction | NextHandleFunction
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import * as connect from 'connect'
 import {FastifyPluginCallback} from 'fastify'
 import * as http from "http";
 
-interface IncomingMessageExtended {
+export interface IncomingMessageExtended {
   body?: any;
   query?: any;
 }

--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ function middiePlugin (fastify, options, next) {
       req.raw.ip = req.ip
       req.raw.ips = req.ips
       req.raw.log = req.log
+      req.raw.body = req.body
+      req.raw.query = req.query
       reply.raw.log = req.log
       this[kMiddie].run(req.raw, reply.raw, next)
     } else {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,11 +1,14 @@
 import fastify from "fastify";
-import middiePlugin, {MiddiePluginOptions} from "..";
+import middiePlugin, {MiddiePluginOptions, IncomingMessageExtended} from "..";
 import { expectAssignable } from "tsd";
 
 const app = fastify();
 app.register(middiePlugin);
 
 expectAssignable<MiddiePluginOptions>({})
+
+expectAssignable<IncomingMessageExtended>({ body: { foo: 'bar' }, query: { bar: 'foo' }})
+expectAssignable<IncomingMessageExtended>({})
 
 app.use('/', (_req, _res, next) => {
   next()

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,16 +1,18 @@
 import fastify from "fastify";
 import middiePlugin, {MiddiePluginOptions, IncomingMessageExtended} from "..";
-import { expectAssignable } from "tsd";
+import { expectAssignable, expectType } from "tsd";
 
 const app = fastify();
 app.register(middiePlugin);
 
 expectAssignable<MiddiePluginOptions>({})
-expectAssignable<MiddiePluginOptions>({ hook: 'preHandler' })
 
 expectAssignable<IncomingMessageExtended>({ body: { foo: 'bar' }, query: { bar: 'foo' }})
 expectAssignable<IncomingMessageExtended>({})
 
 app.use('/', (_req, _res, next) => {
+  expectType<any | undefined>(_req.body)
+  expectType<any | undefined>(_req.body)
+
   next()
 })

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -12,7 +12,7 @@ expectAssignable<IncomingMessageExtended>({})
 
 app.use('/', (_req, _res, next) => {
   expectType<any | undefined>(_req.body)
-  expectType<any | undefined>(_req.body)
+  expectType<any | undefined>(_req.query)
 
   next()
 })


### PR DESCRIPTION
Allows access to `query`, and `body` when it is available (in `preValidation` hook onwards)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
