### PR TITLE
Preparation for the deprecation of http.ServerResponse.finished

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -77,7 +77,7 @@ function middie (complete) {
 
       req.url = req.originalUrl
 
-      if (res.finished === true) {
+      if (res.finished === true || res.writableEnded === true) {
         that.req = null
         that.res = null
         that.context = null

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -467,7 +467,7 @@ test('should match the same slashed path', t => {
   instance.run(req, res)
 })
 
-test('if the function calls res.end the iterator should stop', t => {
+test('if the function calls res.end the iterator should stop / 1 (with deprecated finished flag)', t => {
   t.plan(1)
 
   const instance = middie(function () {
@@ -487,6 +487,28 @@ test('if the function calls res.end the iterator should stop', t => {
   instance
     .use(function (req, res, next) {
       res.end('hello')
+      next()
+    })
+    .use(function (req, res, next) {
+      t.fail('we should not be here')
+    })
+
+  instance.run(req, res)
+})
+
+test('if the function calls res.end the iterator should stop / 2', t => {
+  t.plan(0)
+
+  const instance = middie(function () {
+    t.fail('we should not be here')
+  })
+  const req = new http.IncomingMessage(null)
+  req.url = '/test'
+  const res = new http.ServerResponse(req)
+
+  instance
+    .use(function (req, res, next) {
+      res.end('bye')
       next()
     })
     .use(function (req, res, next) {


### PR DESCRIPTION
#### Checklist

- [X] run `npm run test`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Changes

As documented with [DEP0136](https://nodejs.org/api/deprecations.html#dep0136-http-finished), `http.ServerResponse.finished` is deprecated in node v12. This PR introduces its successor `http.ServerResponse.writableEnded`