### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If you need to run a middleware only under certain path(s), just pass the path a
 
 ```js
 const fastify = require('fastify')()
-const path = require('path')
+const path = require('node:path')
 const serveStatic = require('serve-static')
 
 fastify
@@ -167,7 +167,7 @@ You can also use the engine itself without the Fastify plugin system.
 ## Usage
 ```js
 const Middie = require('@fastify/middie/engine')
-const http = require('http')
+const http = require('node:http')
 const helmet = require('helmet')
 const cors = require('cors')
 

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -2,8 +2,8 @@
 
 const middie = require('../lib/engine')
 const t = require('tap')
-const http = require('http')
-const { join } = require('path')
+const http = require('node:http')
+const { join } = require('node:path')
 const serveStatic = require('serve-static')
 const test = t.test
 

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -9,7 +9,7 @@ const fastify = require('fastify')
 const fp = require('fastify-plugin')
 const cors = require('cors')
 const helmet = require('helmet')
-const fs = require('fs')
+const fs = require('node:fs')
 
 const middiePlugin = require('../index')
 


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
