### PR TITLE
Only sets req.raw.body if body defined, aligning behaviour with node:http

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,9 +67,9 @@ function fastifyMiddie (fastify, options, next) {
       req.raw.ip = req.ip
       req.raw.ips = req.ips
       req.raw.log = req.log
-      req.raw.body = req.body
       req.raw.query = req.query
       reply.raw.log = req.log
+      if (req.body !== undefined) req.raw.body = req.body
       this[kMiddie].run(req.raw, reply.raw, next)
     } else {
       next()

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -84,7 +84,7 @@ test('Should not enhance the Node.js core request/response objects when there ar
   })
 })
 
-test('If the enhanced response body is undefined, the body key should not be defined', (t) => {
+test('If the enhanced response body is undefined, the body key should not exist', (t) => {
   t.plan(3)
   const fastify = Fastify()
   t.teardown(fastify.close)

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -83,3 +83,30 @@ test('Should not enhance the Node.js core request/response objects when there ar
     )
   })
 })
+
+test('If the enhanced response body is undefined, the body key should not be defined', (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+  t.teardown(fastify.close)
+
+  fastify.register(middiePlugin).after(() => {
+    fastify.use(cors())
+    fastify.use((req, res, next) => {
+      t.equal('body' in req, false)
+      next()
+    })
+  })
+
+  fastify.listen({ port: 0 }, (err, address) => {
+    t.error(err)
+    sget(
+      {
+        method: 'POST',
+        url: `${address}?foo=bar`
+      },
+      (err, res, data) => {
+        t.error(err)
+      }
+    )
+  })
+})


### PR DESCRIPTION
Currently Middie's undefined req.body handling does not align with `node:http` and `express`. Their behaviour, If the body has not been parsed with a body parser and is undefined, the `body` key will not be present within the request. Maddie includes the `body` key with an undefined value.

I've created this PR as the library `@octokit/webhooks` does not currently work with Middie[0] because of this issue. I also feel it would be beneficial to align the behaviour where possible.

Apologies, I haven't run the benchmark script, I don't see it available on main. Have I missed something?

[0] https://github.com/octokit/webhooks.js/issues/1009

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
