### PR TITLE
chore: bump path-to-regexp to 8.1.0

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -20,10 +20,10 @@ function middie (complete) {
 
     let regexp
     if (url) {
-      regexp = pathToRegexp(sanitizePrefixUrl(url), [], {
-        end: false,
-        strict: false
+      const pathRegExp = pathToRegexp(sanitizePrefixUrl(url), {
+        end: false
       })
+      regexp = pathRegExp.regexp
     }
 
     if (Array.isArray(f)) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fastify/error": "^4.0.0",
     "fastify-plugin": "^5.0.0",
-    "path-to-regexp": "^6.2.2",
+    "path-to-regexp": "^8.1.0",
     "reusify": "^1.0.4"
   },
   "publishConfig": {


### PR DESCRIPTION
Close #211

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
