### PR TITLE
fix(8.x): use path-to-regexp@6.3.0

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -20,10 +20,10 @@ function middie (complete) {
 
     let regexp
     if (url) {
-      const pathRegExp = pathToRegexp(sanitizePrefixUrl(url), {
-        end: false
+      regexp = pathToRegexp(sanitizePrefixUrl(url), [], {
+        end: false,
+        strict: true
       })
-      regexp = pathRegExp.regexp
     }
 
     if (Array.isArray(f)) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@fastify/error": "^3.2.0",
     "fastify-plugin": "^4.0.0",
-    "path-to-regexp": "^8.1.0",
+    "path-to-regexp": "^6.3.0",
     "reusify": "^1.0.4"
   },
   "publishConfig": {


### PR DESCRIPTION
Since `path-to-regexp` published new version for it's `6.x` release line.
To reduce the breaking change for most users, I consider use `6.3.0` in the `8.x` release line for `@fastify/middie`.
I will deprecated the `8.3.2` version once this is accepted.

Resolves #214

cc @fastify/core 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
