### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import * as connect from 'connect'
 import { FastifyPluginCallback } from 'fastify'
-import * as http from 'http'
+import * as http from 'node:http'
 
 declare module 'fastify' {
   interface FastifyInstance {


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.