### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/connect": "^3.4.38",
     "@types/node": "^22.0.0",
     "cors": "^2.8.5",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "helmet": "^8.0.0",
     "neostandard": "^0.12.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.