### PR TITLE
test: migrate from tap to node:test

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -127,7 +127,6 @@ function sanitizeUrl (url) {
 }
 
 function sanitizePrefixUrl (url) {
-  if (url === '') return url
   if (url === '/') return ''
   if (url[url.length - 1] === '/') return url.slice(0, -1)
   return url

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
   "type": "commonjs",
   "types": "types/index.d.ts",
   "scripts": {
-    "coverage": "c8 node --test",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "node --test",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "type": "commonjs",
   "types": "types/index.d.ts",
   "scripts": {
-    "coverage": "tap --cov --coverage-report=html test.js",
+    "coverage": "c8 node --test",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "test": "tap test/*.test.js && tsd",
-    "test:unit": "tap",
+    "test": "node --test test/*.test.js && tsd",
+    "test:unit": "node --test test/*.test.js",
     "test:typescript": "tsd"
   },
   "keywords": [
@@ -62,6 +62,7 @@
     "@fastify/pre-commit": "^2.1.0",
     "@types/connect": "^3.4.38",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.3",
     "cors": "^2.8.5",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",
@@ -69,7 +70,6 @@
     "neostandard": "^0.12.0",
     "serve-static": "^1.15.0",
     "simple-get": "^4.0.1",
-    "tap": "^18.7.2",
     "tsd": "^0.31.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "coverage": "c8 node --test",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "test": "node --test test/*.test.js && tsd",
-    "test:unit": "node --test test/*.test.js",
+    "test": "npm run test:unit && npm run test:typescript",
+    "test:unit": "node --test",
     "test:typescript": "tsd"
   },
   "keywords": [

--- a/test/404s.test.js
+++ b/test/404s.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const fp = require('fastify-plugin')
 const Fastify = require('fastify')
 const sget = require('simple-get').concat
 const middiePlugin = require('../index')
 
-test('run hooks and middleware on default 404', t => {
+test('run hooks and middleware on default 404', (t, done) => {
   t.plan(8)
 
   const fastify = Fastify()
@@ -15,28 +15,28 @@ test('run hooks and middleware on default 404', t => {
     .register(middiePlugin)
     .after(() => {
       fastify.use(function (_req, _res, next) {
-        t.pass('middleware called')
+        t.assert.ok('middleware called')
         next()
       })
     })
 
   fastify.addHook('onRequest', function (_req, _res, next) {
-    t.pass('onRequest called')
+    t.assert.ok('onRequest called')
     next()
   })
 
   fastify.addHook('preHandler', function (_request, _reply, next) {
-    t.pass('preHandler called')
+    t.assert.ok('preHandler called')
     next()
   })
 
   fastify.addHook('onSend', function (_request, _reply, _payload, next) {
-    t.pass('onSend called')
+    t.assert.ok('onSend called')
     next()
   })
 
   fastify.addHook('onResponse', function (_request, _reply, next) {
-    t.pass('onResponse called')
+    t.assert.ok('onResponse called')
     next()
   })
 
@@ -44,10 +44,10 @@ test('run hooks and middleware on default 404', t => {
     reply.send({ hello: 'world' })
   })
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'PUT',
@@ -55,42 +55,43 @@ test('run hooks and middleware on default 404', t => {
       body: JSON.stringify({ hello: 'world' }),
       headers: { 'Content-Type': 'application/json' }
     }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })
 
-test('run non-encapsulated plugin hooks and middleware on default 404', t => {
+test('run non-encapsulated plugin hooks and middleware on default 404', (t, done) => {
   t.plan(8)
 
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
   fastify.register(middiePlugin)
 
   fastify.register(fp(function (instance, _options, next) {
     instance.addHook('onRequest', function (_req, _res, next) {
-      t.pass('onRequest called')
+      t.assert.ok('onRequest called')
       next()
     })
 
     instance.use(function (_req, _res, next) {
-      t.pass('middleware called')
+      t.assert.ok('middleware called')
       next()
     })
 
     instance.addHook('preHandler', function (_request, _reply, next) {
-      t.pass('preHandler called')
+      t.assert.ok('preHandler called')
       next()
     })
 
     instance.addHook('onSend', function (_request, _reply, _payload, next) {
-      t.pass('onSend called')
+      t.assert.ok('onSend called')
       next()
     })
 
     instance.addHook('onResponse', function (_request, _reply, next) {
-      t.pass('onResponse called')
+      t.assert.ok('onResponse called')
       next()
     })
 
@@ -102,49 +103,50 @@ test('run non-encapsulated plugin hooks and middleware on default 404', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'POST',
       url: address,
       body: JSON.stringify({ hello: 'world' }),
       headers: { 'Content-Type': 'application/json' }
     }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })
 
-test('run non-encapsulated plugin hooks and middleware on custom 404', t => {
+test('run non-encapsulated plugin hooks and middleware on custom 404', (t, done) => {
   t.plan(14)
 
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
   fastify.register(middiePlugin)
 
   const plugin = fp((instance, _opts, next) => {
     instance.addHook('onRequest', function (_req, _res, next) {
-      t.pass('onRequest called')
+      t.assert.ok('onRequest called')
       next()
     })
 
     instance.use(function (_req, _res, next) {
-      t.pass('middleware called')
+      t.assert.ok('middleware called')
       next()
     })
 
     instance.addHook('preHandler', function (_request, _reply, next) {
-      t.pass('preHandler called')
+      t.assert.ok('preHandler called')
       next()
     })
 
     instance.addHook('onSend', function (_request, _reply, _payload, next) {
-      t.pass('onSend called')
+      t.assert.ok('onSend called')
       next()
     })
 
     instance.addHook('onResponse', function (_request, _reply, next) {
-      t.pass('onResponse called')
+      t.assert.ok('onResponse called')
       next()
     })
 
@@ -164,19 +166,20 @@ test('run non-encapsulated plugin hooks and middleware on custom 404', t => {
   fastify.register(plugin) // Registering plugin after handler also works
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address + '/not-found'
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(body.toString(), 'this was not found')
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(body.toString(), 'this was not found')
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })
 
-test('run hooks and middleware with encapsulated 404', t => {
+test('run hooks and middleware with encapsulated 404', (t, done) => {
   t.plan(13)
 
   const fastify = Fastify()
@@ -185,28 +188,28 @@ test('run hooks and middleware with encapsulated 404', t => {
     .register(middiePlugin)
     .after(() => {
       fastify.use(function (_req, _res, next) {
-        t.pass('middleware called')
+        t.assert.ok('middleware called')
         next()
       })
     })
 
   fastify.addHook('onRequest', function (_req, _res, next) {
-    t.pass('onRequest called')
+    t.assert.ok('onRequest called')
     next()
   })
 
   fastify.addHook('preHandler', function (_request, _reply, next) {
-    t.pass('preHandler called')
+    t.assert.ok('preHandler called')
     next()
   })
 
   fastify.addHook('onSend', function (_request, _reply, _payload, next) {
-    t.pass('onSend called')
+    t.assert.ok('onSend called')
     next()
   })
 
   fastify.addHook('onResponse', function (_request, _reply, next) {
-    t.pass('onResponse called')
+    t.assert.ok('onResponse called')
     next()
   })
 
@@ -216,37 +219,37 @@ test('run hooks and middleware with encapsulated 404', t => {
     })
 
     f.addHook('onRequest', function (_req, _res, next) {
-      t.pass('onRequest 2 called')
+      t.assert.ok('onRequest 2 called')
       next()
     })
 
     f.use(function (_req, _res, next) {
-      t.pass('middleware 2 called')
+      t.assert.ok('middleware 2 called')
       next()
     })
 
     f.addHook('preHandler', function (_request, _reply, next) {
-      t.pass('preHandler 2 called')
+      t.assert.ok('preHandler 2 called')
       next()
     })
 
     f.addHook('onSend', function (_request, _reply, _payload, next) {
-      t.pass('onSend 2 called')
+      t.assert.ok('onSend 2 called')
       next()
     })
 
     f.addHook('onResponse', function (_request, _reply, next) {
-      t.pass('onResponse 2 called')
+      t.assert.ok('onResponse 2 called')
       next()
     })
 
     next()
   }, { prefix: '/test' })
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'PUT',
@@ -254,13 +257,14 @@ test('run hooks and middleware with encapsulated 404', t => {
       body: JSON.stringify({ hello: 'world' }),
       headers: { 'Content-Type': 'application/json' }
     }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })
 
-test('run middlewares on default 404', t => {
+test('run middlewares on default 404', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify()
@@ -268,7 +272,7 @@ test('run middlewares on default 404', t => {
     .register(middiePlugin)
     .after(() => {
       fastify.use(function (_req, _res, next) {
-        t.pass('middleware called')
+        t.assert.ok('middleware called')
         next()
       })
     })
@@ -277,10 +281,10 @@ test('run middlewares on default 404', t => {
     reply.send({ hello: 'world' })
   })
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'PUT',
@@ -288,13 +292,14 @@ test('run middlewares on default 404', t => {
       body: JSON.stringify({ hello: 'world' }),
       headers: { 'Content-Type': 'application/json' }
     }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })
 
-test('run middlewares with encapsulated 404', t => {
+test('run middlewares with encapsulated 404', (t, done) => {
   t.plan(5)
 
   const fastify = Fastify()
@@ -302,7 +307,7 @@ test('run middlewares with encapsulated 404', t => {
     .register(middiePlugin)
     .after(() => {
       fastify.use(function (_req, _res, next) {
-        t.pass('middleware called')
+        t.assert.ok('middleware called')
         next()
       })
     })
@@ -313,17 +318,17 @@ test('run middlewares with encapsulated 404', t => {
     })
 
     f.use(function (_req, _res, next) {
-      t.pass('middleware 2 called')
+      t.assert.ok('middleware 2 called')
       next()
     })
 
     next()
   }, { prefix: '/test' })
 
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
     sget({
       method: 'PUT',
@@ -331,8 +336,9 @@ test('run middlewares with encapsulated 404', t => {
       body: JSON.stringify({ hello: 'world' }),
       headers: { 'Content-Type': 'application/json' }
     }, (err, response) => {
-      t.error(err)
-      t.equal(response.statusCode, 404)
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 404)
+      done()
     })
   })
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const sget = require('simple-get').concat
 const cors = require('cors')
@@ -8,10 +8,10 @@ const cors = require('cors')
 const middiePlugin = require('../index')
 const { FST_ERR_MIDDIE_INVALID_HOOK } = require('../lib/errors')
 
-test('Should support connect style middlewares', t => {
+test('Should support connect style middlewares', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify
     .register(middiePlugin)
@@ -22,24 +22,23 @@ test('Should support connect style middlewares', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address
     }, (err, res, data) => {
-      t.error(err)
-      t.match(res.headers, {
-        'access-control-allow-origin': '*'
-      })
-      t.same(JSON.parse(data), { hello: 'world' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['access-control-allow-origin'], '*')
+      t.assert.deepStrictEqual(JSON.parse(data), { hello: 'world' })
+      done()
     })
   })
 })
 
-test('Should support connect style middlewares (async await)', async t => {
+test('Should support connect style middlewares (async await)', async (t) => {
   t.plan(3)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   await fastify.register(middiePlugin)
   fastify.use(cors())
@@ -54,11 +53,9 @@ test('Should support connect style middlewares (async await)', async t => {
       method: 'GET',
       url: address
     }, (err, res, data) => {
-      t.error(err)
-      t.match(res.headers, {
-        'access-control-allow-origin': '*'
-      })
-      t.same(JSON.parse(data), { hello: 'world' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['access-control-allow-origin'], '*')
+      t.assert.deepStrictEqual(JSON.parse(data), { hello: 'world' })
       resolve()
     })
   })
@@ -67,7 +64,7 @@ test('Should support connect style middlewares (async await)', async t => {
 test('Should support connect style middlewares (async await after)', async t => {
   t.plan(3)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin)
   await fastify.after()
@@ -83,20 +80,18 @@ test('Should support connect style middlewares (async await after)', async t => 
       method: 'GET',
       url: address
     }, (err, res, data) => {
-      t.error(err)
-      t.match(res.headers, {
-        'access-control-allow-origin': '*'
-      })
-      t.same(JSON.parse(data), { hello: 'world' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['access-control-allow-origin'], '*')
+      t.assert.deepStrictEqual(JSON.parse(data), { hello: 'world' })
       resolve()
     })
   })
 })
 
-test('Should support per path middlewares', t => {
+test('Should support per path middlewares', (t, done) => {
   t.plan(5)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify
     .register(middiePlugin)
@@ -111,28 +106,27 @@ test('Should support per path middlewares', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address + '/cors/hello'
     }, (err, res) => {
-      t.error(err)
-      t.match(res.headers, {
-        'access-control-allow-origin': '*'
-      })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['access-control-allow-origin'], '*')
     })
 
     sget({
       method: 'GET',
       url: address
     }, (err, res) => {
-      t.error(err)
-      t.notOk(res.headers['access-control-allow-origin'])
+      t.assert.ifError(err)
+      t.assert.ok(!res.headers['access-control-allow-origin'])
+      done()
     })
   })
 })
 
-test('Encapsulation support / 1', t => {
+test('Encapsulation support / 1', (t, done) => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -153,22 +147,23 @@ test('Encapsulation support / 1', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address
     }, (err) => {
-      t.error(err)
+      t.assert.ifError(err)
       fastify.close()
+      done()
     })
   })
 
   function middleware () {
-    t.fail('Shuld not be called')
+    t.assert.fail('Shuld not be called')
   }
 })
 
-test('Encapsulation support / 2', t => {
+test('Encapsulation support / 2', (t, done) => {
   t.plan(2)
 
   const fastify = Fastify()
@@ -189,27 +184,28 @@ test('Encapsulation support / 2', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address
     }, (err) => {
-      t.error(err)
+      t.assert.ifError(err)
       fastify.close()
+      done()
     })
   })
 
   function middleware () {
-    t.fail('Shuld not be called')
+    t.assert.fail('Shuld not be called')
   }
 })
 
-test('Encapsulation support / 3', t => {
+test('Encapsulation support / 3', (t, done) => {
   t.plan(5)
 
   const fastify = Fastify()
 
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin)
 
@@ -227,35 +223,32 @@ test('Encapsulation support / 3', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address + '/plugin'
     }, (err, res) => {
-      t.error(err)
-      t.match(res.headers, {
-        'access-control-allow-origin': '*'
-      })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['access-control-allow-origin'], '*')
     })
 
     sget({
       method: 'GET',
       url: address
     }, (err, res) => {
-      t.error(err)
-      t.notMatch(res.headers, {
-        'access-control-allow-origin': '*'
-      })
+      t.assert.ifError(err)
+      t.assert.notStrictEqual(res.headers['access-control-allow-origin'], '*')
+      done()
     })
   })
 })
 
-test('Encapsulation support / 4', t => {
-  t.plan(5)
+test('Encapsulation support / 4', (t, done) => {
+  t.plan(6)
 
   const fastify = Fastify()
 
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin)
   fastify.after(() => {
@@ -276,26 +269,23 @@ test('Encapsulation support / 4', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address + '/plugin'
     }, (err, res) => {
-      t.error(err)
-      t.match(res.headers, {
-        'x-middleware-1': 'true',
-        'x-middleware-2': 'true'
-      })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['x-middleware-1'], 'true')
+      t.assert.strictEqual(res.headers['x-middleware-2'], 'true')
     })
 
     sget({
       method: 'GET',
       url: address
     }, (err, res) => {
-      t.error(err)
-      t.match(res.headers, {
-        'x-middleware-1': 'true'
-      })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['x-middleware-1'], 'true')
+      done()
     })
   })
 
@@ -310,12 +300,12 @@ test('Encapsulation support / 4', t => {
   }
 })
 
-test('Encapsulation support / 5', t => {
-  t.plan(7)
+test('Encapsulation support / 5', (t, done) => {
+  t.plan(10)
 
   const fastify = Fastify()
 
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin)
   fastify.after(() => {
@@ -345,38 +335,33 @@ test('Encapsulation support / 5', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address + '/plugin/nested'
     }, (err, res) => {
-      t.error(err)
-      t.match(res.headers, {
-        'x-middleware-1': 'true',
-        'x-middleware-2': 'true',
-        'x-middleware-3': 'true'
-      })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['x-middleware-1'], 'true')
+      t.assert.strictEqual(res.headers['x-middleware-2'], 'true')
+      t.assert.strictEqual(res.headers['x-middleware-3'], 'true')
     })
 
     sget({
       method: 'GET',
       url: address + '/plugin'
     }, (err, res) => {
-      t.error(err)
-      t.match(res.headers, {
-        'x-middleware-1': 'true',
-        'x-middleware-2': 'true'
-      })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['x-middleware-1'], 'true')
+      t.assert.strictEqual(res.headers['x-middleware-2'], 'true')
     })
 
     sget({
       method: 'GET',
       url: address
     }, (err, res) => {
-      t.error(err)
-      t.match(res.headers, {
-        'x-middleware-1': 'true'
-      })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['x-middleware-1'], 'true')
+      done()
     })
   })
 
@@ -396,7 +381,7 @@ test('Encapsulation support / 5', t => {
   }
 })
 
-test('Middleware chain', t => {
+test('Middleware chain', (t, done) => {
   t.plan(5)
 
   const order = [1, 2, 3]
@@ -416,33 +401,34 @@ test('Middleware chain', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address
     }, (err) => {
-      t.error(err)
+      t.assert.ifError(err)
       fastify.close()
+      done()
     })
   })
 
   function middleware1 (_req, _res, next) {
-    t.equal(order.shift(), 1)
+    t.assert.strictEqual(order.shift(), 1)
     next()
   }
 
   function middleware2 (_req, _res, next) {
-    t.equal(order.shift(), 2)
+    t.assert.strictEqual(order.shift(), 2)
     next()
   }
 
   function middleware3 (_req, _res, next) {
-    t.equal(order.shift(), 3)
+    t.assert.strictEqual(order.shift(), 3)
     next()
   }
 })
 
-test('Middleware chain (with errors) / 1', t => {
+test('Middleware chain (with errors) / 1', (t, done) => {
   t.plan(3)
 
   const fastify = Fastify()
@@ -461,14 +447,15 @@ test('Middleware chain (with errors) / 1', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address
     }, (err, res, _data) => {
-      t.error(err)
-      t.equal(res.statusCode, 500)
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.statusCode, 500)
       fastify.close()
+      done()
     })
   })
 
@@ -485,13 +472,13 @@ test('Middleware chain (with errors) / 1', t => {
   }
 })
 
-test('Middleware chain (with errors) / 2', t => {
+test('Middleware chain (with errors) / 2', (t, done) => {
   t.plan(5)
 
   const fastify = Fastify()
 
   fastify.setErrorHandler((err, _req, reply) => {
-    t.equal(err.message, 'middleware2')
+    t.assert.strictEqual(err.message, 'middleware2')
     reply.send(err)
   })
 
@@ -509,19 +496,20 @@ test('Middleware chain (with errors) / 2', t => {
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address
     }, (err, res, _data) => {
-      t.error(err)
-      t.equal(res.statusCode, 500)
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.statusCode, 500)
       fastify.close()
+      done()
     })
   })
 
   function middleware1 (_req, _res, next) {
-    t.pass('called')
+    t.assert.ok('called')
     next()
   }
 
@@ -530,11 +518,11 @@ test('Middleware chain (with errors) / 2', t => {
   }
 
   function middleware3 () {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   }
 })
 
-test('Send a response from a middleware', t => {
+test('Send a response from a middleware', (t, done) => {
   t.plan(4)
 
   const fastify = Fastify()
@@ -548,40 +536,41 @@ test('Send a response from a middleware', t => {
     })
 
   fastify.addHook('preValidation', () => {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   })
 
   fastify.addHook('preParsing', () => {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   })
 
   fastify.addHook('preHandler', () => {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   })
 
   fastify.addHook('onSend', () => {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   })
 
   fastify.addHook('onResponse', (_req, _reply, next) => {
-    t.ok('called')
+    t.assert.ok('called')
     next()
   })
 
   fastify.get('/', () => {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address,
       json: true
     }, (err, _res, data) => {
-      t.error(err)
-      t.same(data, { hello: 'world' })
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(data, { hello: 'world' })
       fastify.close()
+      done()
     })
   })
 
@@ -590,14 +579,14 @@ test('Send a response from a middleware', t => {
   }
 
   function middleware2 (_req, _res, _next) {
-    t.fail('We should not be here')
+    t.assert.fail('We should not be here')
   }
 })
 
-test('Should support plugin level prefix', t => {
+test('Should support plugin level prefix', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin)
 
@@ -615,14 +604,15 @@ test('Should support plugin level prefix', t => {
   }, { prefix: '/hello' })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget({
       method: 'GET',
       url: address + '/hello/world'
     }, (err, res, data) => {
-      t.error(err)
-      t.equal(res.headers['x-foo'], 'bar')
-      t.same(JSON.parse(data), { hello: 'world' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(res.headers['x-foo'], 'bar')
+      t.assert.deepStrictEqual(JSON.parse(data), { hello: 'world' })
+      done()
     })
   })
 })
@@ -631,7 +621,7 @@ test('register the middleware at preHandler hook', async t => {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   let onRequestCalled = false
 
@@ -640,7 +630,7 @@ test('register the middleware at preHandler hook', async t => {
   })
 
   fastify.use(function (_req, _res, next) {
-    t.ok(onRequestCalled)
+    t.assert.ok(onRequestCalled)
     next()
   })
 
@@ -654,14 +644,14 @@ test('register the middleware at preHandler hook', async t => {
   })
 
   const res = await fastify.inject('/')
-  t.same(res.json(), { hello: 'world' })
+  t.assert.deepStrictEqual(res.json(), { hello: 'world' })
 })
 
 test('register the middleware at preParsing hook', async t => {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   let onRequestCalled = false
 
@@ -670,7 +660,7 @@ test('register the middleware at preParsing hook', async t => {
   })
 
   fastify.use(function (_req, _res, next) {
-    t.ok(onRequestCalled)
+    t.assert.ok(onRequestCalled)
     next()
   })
 
@@ -684,14 +674,14 @@ test('register the middleware at preParsing hook', async t => {
   })
 
   const res = await fastify.inject('/')
-  t.same(res.json(), { hello: 'world' })
+  t.assert.deepStrictEqual(res.json(), { hello: 'world' })
 })
 
 test('register the middleware at preValidation hook', async t => {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   let onRequestCalled = false
 
@@ -700,7 +690,7 @@ test('register the middleware at preValidation hook', async t => {
   })
 
   fastify.use(function (_req, _res, next) {
-    t.ok(onRequestCalled)
+    t.assert.ok(onRequestCalled)
     next()
   })
 
@@ -714,14 +704,14 @@ test('register the middleware at preValidation hook', async t => {
   })
 
   const res = await fastify.inject('/')
-  t.same(res.json(), { hello: 'world' })
+  t.assert.deepStrictEqual(res.json(), { hello: 'world' })
 })
 
 test('register the middleware at preSerialization hook', async t => {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   let onRequestCalled = false
 
@@ -730,7 +720,7 @@ test('register the middleware at preSerialization hook', async t => {
   })
 
   fastify.use(function (_req, _res, next) {
-    t.ok(onRequestCalled)
+    t.assert.ok(onRequestCalled)
     next()
   })
 
@@ -744,14 +734,14 @@ test('register the middleware at preSerialization hook', async t => {
   })
 
   const res = await fastify.inject('/')
-  t.same(res.json(), { hello: 'world' })
+  t.assert.deepStrictEqual(res.json(), { hello: 'world' })
 })
 
 test('register the middleware at onSend hook', async t => {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   let onRequestCalled = false
 
@@ -760,7 +750,7 @@ test('register the middleware at onSend hook', async t => {
   })
 
   fastify.use(function (_req, _res, next) {
-    t.ok(onRequestCalled)
+    t.assert.ok(onRequestCalled)
     next()
   })
 
@@ -774,14 +764,14 @@ test('register the middleware at onSend hook', async t => {
   })
 
   const res = await fastify.inject('/')
-  t.same(res.json(), { hello: 'world' })
+  t.assert.deepStrictEqual(res.json(), { hello: 'world' })
 })
 
 test('throw error when registering middie at onRequestAborted hook', async t => {
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
-  t.rejects(async () => fastify.register(middiePlugin, {
+  t.assert.rejects(async () => fastify.register(middiePlugin, {
     hook: 'onRequestAborted'
   }), new FST_ERR_MIDDIE_INVALID_HOOK('onRequestAborted')
   )

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -464,11 +464,11 @@ test('Middleware chain (with errors) / 1', (t, done) => {
   }
 
   function middleware2 () {
-    t.fail('this should not be executed')
+    t.assert.fail('this should not be executed')
   }
 
   function middleware3 () {
-    t.fail('this should not be executed')
+    t.assert.fail('this should not be executed')
   }
 })
 

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const middie = require('../lib/engine')
-const t = require('tap')
+const t = require('node:test')
 const http = require('node:http')
 const { join } = require('node:path')
 const serveStatic = require('serve-static')
@@ -11,9 +11,9 @@ test('use no function', t => {
   t.plan(3)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual(b, res)
   })
 
   const req = {
@@ -28,17 +28,17 @@ test('use a function', t => {
   t.plan(5)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test'
   }
   const res = {}
 
-  t.equal(instance.use(function (_req, _res, next) {
-    t.pass('function called')
+  t.assert.strictEqual(instance.use(function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
@@ -49,9 +49,9 @@ test('use two functions', t => {
   t.plan(5)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test'
@@ -60,10 +60,10 @@ test('use two functions', t => {
   let counter = 0
 
   instance.use(function (_req, _res, next) {
-    t.equal(counter++, 0, 'first function called')
+    t.assert.strictEqual(counter++, 0, 'first function called')
     next()
   }).use(function (_req, _res, next) {
-    t.equal(counter++, 1, 'second function called')
+    t.assert.strictEqual(counter++, 1, 'second function called')
     next()
   })
 
@@ -74,7 +74,7 @@ test('stop the middleware chain if one errors', t => {
   t.plan(1)
 
   const instance = middie(function (err) {
-    t.ok(err, 'error is forwarded')
+    t.assert.ok(err, 'error is forwarded')
   })
   const req = {
     url: '/test'
@@ -95,32 +95,32 @@ test('run restricted by path', t => {
   t.plan(11)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal('/test', req.url)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual('/test', req.url)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test'
   }
   const res = {}
 
-  t.equal(instance.use(function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use(function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use('/test', function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use('/test', function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use('/test', function (req, _res, next) {
-    t.equal('/', req.url)
+  t.assert.strictEqual(instance.use('/test', function (req, _res, next) {
+    t.assert.strictEqual('/', req.url)
     next()
   }), instance)
 
-  t.equal(instance.use('/no-call', function (_req, _res, next) {
+  t.assert.strictEqual(instance.use('/no-call', function (_req, _res, next) {
     t.fail('should not call this function')
     next()
   }), instance)
@@ -132,28 +132,28 @@ test('run restricted by path - prefix override', t => {
   t.plan(10)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal('/test/other/one', req.url)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual('/test/other/one', req.url)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test/other/one'
   }
   const res = {}
 
-  t.equal(instance.use(function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use(function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use('/test', function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use('/test', function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use('/test', function (req, _res, next) {
-    t.equal('/other/one', req.url)
+  t.assert.strictEqual(instance.use('/test', function (req, _res, next) {
+    t.assert.strictEqual('/other/one', req.url)
     next()
   }), instance)
 
@@ -164,28 +164,28 @@ test('run restricted by path - prefix override 2', t => {
   t.plan(10)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal('/tasks-api/task', req.url)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual('/tasks-api/task', req.url)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/tasks-api/task'
   }
   const res = {}
 
-  t.equal(instance.use(function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use(function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use('/tasks-api', function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use('/tasks-api', function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use('/tasks-api', function (req, _res, next) {
-    t.equal('/task', req.url)
+  t.assert.strictEqual(instance.use('/tasks-api', function (req, _res, next) {
+    t.assert.strictEqual('/task', req.url)
     next()
   }), instance)
 
@@ -196,27 +196,27 @@ test('run restricted by array path', t => {
   t.plan(9)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal('/test', req.url)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual('/test', req.url)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test'
   }
   const res = {}
 
-  t.equal(instance.use(function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use(function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use(['/test', '/other-path'], function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use(['/test', '/other-path'], function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
-  t.equal(instance.use(['/no-call', 'other-path'], function (_req, _res, next) {
+  t.assert.strictEqual(instance.use(['/no-call', 'other-path'], function (_req, _res, next) {
     t.fail('should not call this function')
     next()
   }), instance)
@@ -228,29 +228,29 @@ test('run array of middleware restricted by path', t => {
   t.plan(10)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal('/test', req.url)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual('/test', req.url)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test'
   }
   const res = {}
 
-  t.equal(instance.use([function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use([function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }, function (_req, _res, next) {
-    t.ok('function called')
+    t.assert.ok('function called')
     next()
   }]), instance)
 
-  t.equal(instance.use('/test', [function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use('/test', [function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }, function (_req, _res, next) {
-    t.ok('function called')
+    t.assert.ok('function called')
     next()
   }]), instance)
 
@@ -261,29 +261,29 @@ test('run array of middleware restricted by array path', t => {
   t.plan(10)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal('/test', req.url)
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual('/test', req.url)
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test'
   }
   const res = {}
 
-  t.equal(instance.use([function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use([function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }, function (_req, _res, next) {
-    t.ok('function called')
+    t.assert.ok('function called')
     next()
   }]), instance)
 
-  t.equal(instance.use(['/test', '/other-path'], [function (_req, _res, next) {
-    t.ok('function called')
+  t.assert.strictEqual(instance.use(['/test', '/other-path'], [function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }, function (_req, _res, next) {
-    t.ok('function called')
+    t.assert.ok('function called')
     next()
   }]), instance)
 
@@ -294,18 +294,18 @@ test('Should strip the url to only match the pathname', t => {
   t.plan(6)
 
   const instance = middie(function (err, a, b) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal(req.url, '/test#foo?bin=baz')
-    t.equal(b, res)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual(req.url, '/test#foo?bin=baz')
+    t.assert.strictEqual(b, res)
   })
   const req = {
     url: '/test#foo?bin=baz'
   }
   const res = {}
 
-  t.equal(instance.use('/test', function (_req, _res, next) {
-    t.pass('function called')
+  t.assert.strictEqual(instance.use('/test', function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
@@ -316,18 +316,18 @@ test('should keep the context', t => {
   t.plan(6)
 
   const instance = middie(function (err, a, b, ctx) {
-    t.error(err)
-    t.equal(a, req)
-    t.equal(b, res)
-    t.ok(ctx.key)
+    t.assert.ifError(err)
+    t.assert.strictEqual(a, req)
+    t.assert.strictEqual(b, res)
+    t.assert.ok(ctx.key)
   })
   const req = {
     url: '/test'
   }
   const res = {}
 
-  t.equal(instance.use(function (_req, _res, next) {
-    t.pass('function called')
+  t.assert.strictEqual(instance.use(function (_req, _res, next) {
+    t.assert.ok('function called')
     next()
   }), instance)
 
@@ -338,7 +338,7 @@ test('should add `originalUrl` property to req', t => {
   t.plan(2)
 
   const instance = middie(function (err) {
-    t.error(err)
+    t.assert.ifError(err)
   })
   const req = {
     url: '/test'
@@ -346,14 +346,14 @@ test('should add `originalUrl` property to req', t => {
   const res = {}
 
   instance.use(function (req, _res, next) {
-    t.equal(req.originalUrl, '/test')
+    t.assert.strictEqual(req.originalUrl, '/test')
     next()
   })
 
   instance.run(req, res)
 })
 
-test('basic serve static', t => {
+test('basic serve static', (t, done) => {
   const instance = middie(function () {
     t.fail('the default route should never be called')
   })
@@ -362,16 +362,16 @@ test('basic serve static', t => {
 
   server.listen(0, function () {
     http.get(`http://localhost:${server.address().port}/README.md`, function (res) {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       server.close()
       server.unref()
-      t.end()
+      done()
     })
   })
 })
 
-test('limit serve static to a specific folder', t => {
+test('limit serve static to a specific folder', (t, done) => {
   const instance = middie(function () {
     t.fail('the default route should never be called')
     req.destroy()
@@ -384,11 +384,11 @@ test('limit serve static to a specific folder', t => {
 
   server.listen(0, function () {
     req = http.get(`http://localhost:${server.address().port}/assets/README.md`, function (res) {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       server.close()
       server.unref()
-      t.end()
+      done()
     })
   })
 })
@@ -396,8 +396,8 @@ test('limit serve static to a specific folder', t => {
 test('should match all chain', t => {
   t.plan(2)
   const instance = middie(function (err, req) {
-    t.error(err)
-    t.same(req, {
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(req, {
       url: '/inner/in/depth',
       originalUrl: '/inner/in/depth',
       undefined: true,
@@ -443,8 +443,8 @@ test('should match all chain', t => {
 test('should match the same slashed path', t => {
   t.plan(3)
   const instance = middie(function (err, req) {
-    t.error(err)
-    t.same(req, {
+    t.assert.ifError(err)
+    t.assert.deepStrictEqual(req, {
       url: '/path',
       originalUrl: '/path'
     })
@@ -455,7 +455,7 @@ test('should match the same slashed path', t => {
   const res = {}
 
   instance.use('/path/', function (_req, _res, next) {
-    t.pass('function called')
+    t.assert.ok('function called')
     next()
   })
 
@@ -479,7 +479,7 @@ test('if the function calls res.end the iterator should stop / 1 (with deprecate
   const res = {
     finished: false,
     end: function () {
-      t.pass('res.end')
+      t.assert.ok('res.end')
       this.finished = true
     }
   }

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -84,7 +84,7 @@ test('stop the middleware chain if one errors', t => {
   instance.use(function (_req, _res, next) {
     next(new Error('kaboom'))
   }).use(function (_req, _res, next) {
-    t.fail('this should never be called')
+    t.assert.fail('this should never be called')
     next()
   })
 
@@ -121,7 +121,7 @@ test('run restricted by path', t => {
   }), instance)
 
   t.assert.strictEqual(instance.use('/no-call', function (_req, _res, next) {
-    t.fail('should not call this function')
+    t.assert.fail('should not call this function')
     next()
   }), instance)
 
@@ -217,7 +217,7 @@ test('run restricted by array path', t => {
   }), instance)
 
   t.assert.strictEqual(instance.use(['/no-call', 'other-path'], function (_req, _res, next) {
-    t.fail('should not call this function')
+    t.assert.fail('should not call this function')
     next()
   }), instance)
 
@@ -355,7 +355,7 @@ test('should add `originalUrl` property to req', t => {
 
 test('basic serve static', (t, done) => {
   const instance = middie(function () {
-    t.fail('the default route should never be called')
+    t.assert.fail('the default route should never be called')
   })
   instance.use(serveStatic(join(__dirname, '..')))
   const server = http.createServer(instance.run.bind(instance))
@@ -373,7 +373,7 @@ test('basic serve static', (t, done) => {
 
 test('limit serve static to a specific folder', (t, done) => {
   const instance = middie(function () {
-    t.fail('the default route should never be called')
+    t.assert.fail('the default route should never be called')
     req.destroy()
     server.close()
     server.unref()
@@ -460,7 +460,7 @@ test('should match the same slashed path', t => {
   })
 
   instance.use('/path/inner', function (_req, _res, next) {
-    t.fail()
+    t.assert.fail()
     next()
   })
 
@@ -471,7 +471,7 @@ test('if the function calls res.end the iterator should stop / 1 (with deprecate
   t.plan(1)
 
   const instance = middie(function () {
-    t.fail('we should not be here')
+    t.assert.fail('we should not be here')
   })
   const req = {
     url: '/test'
@@ -490,7 +490,7 @@ test('if the function calls res.end the iterator should stop / 1 (with deprecate
       next()
     })
     .use(function () {
-      t.fail('we should not be here')
+      t.assert.fail('we should not be here')
     })
 
   instance.run(req, res)
@@ -500,7 +500,7 @@ test('if the function calls res.end the iterator should stop / 2', t => {
   t.plan(0)
 
   const instance = middie(function () {
-    t.fail('we should not be here')
+    t.assert.fail('we should not be here')
   })
   const req = new http.IncomingMessage(null)
   req.url = '/test'
@@ -512,7 +512,7 @@ test('if the function calls res.end the iterator should stop / 2', t => {
       next()
     })
     .use(function () {
-      t.fail('we should not be here')
+      t.assert.fail('we should not be here')
     })
 
   instance.run(req, res)

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -1,39 +1,39 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const sget = require('simple-get').concat
 const cors = require('cors')
 
 const middiePlugin = require('../index')
 
-test('Should enhance the Node.js core request/response objects', (t) => {
+test('Should enhance the Node.js core request/response objects', (t, done) => {
   t.plan(14)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin, { hook: 'preHandler' }).after(() => {
     fastify.use(cors())
   })
 
   fastify.post('/', async (req, reply) => {
-    t.equal(req.raw.originalUrl, req.raw.url)
-    t.equal(req.raw.id, req.id)
-    t.equal(req.raw.hostname, req.hostname)
-    t.equal(req.raw.protocol, req.protocol)
-    t.equal(req.raw.ip, req.ip)
-    t.same(req.raw.ips, req.ips)
-    t.same(req.raw.body, req.body)
-    t.same(req.raw.query, req.query)
-    t.ok(req.raw.body.bar)
-    t.ok(req.raw.query.foo)
-    t.ok(req.raw.log)
-    t.ok(reply.raw.log)
+    t.assert.strictEqual(req.raw.originalUrl, req.raw.url)
+    t.assert.strictEqual(req.raw.id, req.id)
+    t.assert.strictEqual(req.raw.hostname, req.hostname)
+    t.assert.strictEqual(req.raw.protocol, req.protocol)
+    t.assert.strictEqual(req.raw.ip, req.ip)
+    t.assert.deepStrictEqual(req.raw.ips, req.ips)
+    t.assert.deepStrictEqual(req.raw.body, req.body)
+    t.assert.deepStrictEqual(req.raw.query, req.query)
+    t.assert.ok(req.raw.body.bar)
+    t.assert.ok(req.raw.query.foo)
+    t.assert.ok(req.raw.log)
+    t.assert.ok(reply.raw.log)
     return { hello: 'world' }
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget(
       {
         method: 'POST',
@@ -42,34 +42,35 @@ test('Should enhance the Node.js core request/response objects', (t) => {
         json: true
       },
       (err) => {
-        t.error(err)
+        t.assert.ifError(err)
+        done()
       }
     )
   })
 })
 
-test('Should not enhance the Node.js core request/response objects when there are no middlewares', (t) => {
+test('Should not enhance the Node.js core request/response objects when there are no middlewares', (t, done) => {
   t.plan(11)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin, { hook: 'preHandler' })
 
   fastify.post('/', async (req, reply) => {
-    t.equal(req.raw.originalUrl, undefined)
-    t.equal(req.raw.id, undefined)
-    t.equal(req.raw.hostname, undefined)
-    t.equal(req.raw.ip, undefined)
-    t.equal(req.raw.ips, undefined)
-    t.same(req.raw.body, undefined)
-    t.same(req.raw.query, undefined)
-    t.notOk(req.raw.log)
-    t.notOk(reply.raw.log)
+    t.assert.strictEqual(req.raw.originalUrl, undefined)
+    t.assert.strictEqual(req.raw.id, undefined)
+    t.assert.strictEqual(req.raw.hostname, undefined)
+    t.assert.strictEqual(req.raw.ip, undefined)
+    t.assert.strictEqual(req.raw.ips, undefined)
+    t.assert.deepStrictEqual(req.raw.body, undefined)
+    t.assert.deepStrictEqual(req.raw.query, undefined)
+    t.assert.ok(!req.raw.log)
+    t.assert.ok(!reply.raw.log)
     return { hello: 'world' }
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget(
       {
         method: 'POST',
@@ -78,34 +79,36 @@ test('Should not enhance the Node.js core request/response objects when there ar
         json: true
       },
       (err) => {
-        t.error(err)
+        t.assert.ifError(err)
+        done()
       }
     )
   })
 })
 
-test('If the enhanced response body is undefined, the body key should not exist', (t) => {
+test('If the enhanced response body is undefined, the body key should not exist', (t, done) => {
   t.plan(3)
   const fastify = Fastify()
-  t.teardown(fastify.close)
+  t.after(() => fastify.close())
 
   fastify.register(middiePlugin).after(() => {
     fastify.use(cors())
     fastify.use((req, _res, next) => {
-      t.equal('body' in req, false)
+      t.assert.strictEqual('body' in req, false)
       next()
     })
   })
 
   fastify.listen({ port: 0 }, (err, address) => {
-    t.error(err)
+    t.assert.ifError(err)
     sget(
       {
         method: 'POST',
         url: `${address}?foo=bar`
       },
       (err) => {
-        t.error(err)
+        t.assert.ifError(err)
+        done()
       }
     )
   })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const middiePlugin = require('../index')
 
-test('onSend hook should receive valid request and reply objects if middleware fails', t => {
+test('onSend hook should receive valid request and reply objects if middleware fails', (t, done) => {
   t.plan(4)
   const fastify = Fastify()
   fastify.register(middiePlugin)
@@ -18,8 +18,8 @@ test('onSend hook should receive valid request and reply objects if middleware f
   fastify.decorateReply('testDecorator', 'testDecoratorVal')
 
   fastify.addHook('onSend', function (request, reply, _payload, next) {
-    t.equal(request.testDecorator, 'testDecoratorVal')
-    t.equal(reply.testDecorator, 'testDecoratorVal')
+    t.assert.strictEqual(request.testDecorator, 'testDecoratorVal')
+    t.assert.strictEqual(reply.testDecorator, 'testDecoratorVal')
     next()
   })
 
@@ -31,7 +31,8 @@ test('onSend hook should receive valid request and reply objects if middleware f
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 500)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 500)
+    done()
   })
 })

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -2,8 +2,7 @@
 
 // Original Fastify test/middlewares.test.js file
 
-const t = require('tap')
-const test = t.test
+const test = require('node:test')
 const sget = require('simple-get').concat
 const fastify = require('fastify')
 const fp = require('fastify-plugin')
@@ -13,18 +12,18 @@ const fs = require('node:fs')
 
 const middiePlugin = require('../index')
 
-test('use a middleware', t => {
+test('use a middleware', (t, done) => {
   t.plan(7)
 
   const instance = fastify()
   instance.register(middiePlugin)
     .after(() => {
       const useRes = instance.use(function (_req, _res, next) {
-        t.pass('middleware called')
+        t.assert.ok('middleware called')
         next()
       })
 
-      t.equal(useRes, instance)
+      t.assert.strictEqual(useRes, instance)
     })
 
   instance.get('/', function (_request, reply) {
@@ -32,23 +31,24 @@ test('use a middleware', t => {
   })
 
   instance.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
-    t.teardown(instance.server.close.bind(instance.server))
+    t.after(() => instance.server.close())
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + instance.server.address().port
     }, (err, response, body) => {
-      t.error(err)
-      t.equal(response.statusCode, 200)
-      t.equal(response.headers['content-length'], '' + body.length)
-      t.same(JSON.parse(body), { hello: 'world' })
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.statusCode, 200)
+      t.assert.strictEqual(response.headers['content-length'], '' + body.length)
+      t.assert.deepStrictEqual(JSON.parse(body), { hello: 'world' })
+      done()
     })
   })
 })
 
-test('use cors', t => {
+test('use cors', (t, done) => {
   t.plan(3)
 
   const instance = fastify()
@@ -62,21 +62,22 @@ test('use cors', t => {
   })
 
   instance.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
-    t.teardown(instance.server.close.bind(instance.server))
+    t.after(() => instance.server.close())
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + instance.server.address().port
     }, (err, response) => {
-      t.error(err)
-      t.equal(response.headers['access-control-allow-origin'], '*')
+      t.assert.ifError(err)
+      t.assert.strictEqual(response.headers['access-control-allow-origin'], '*')
+      done()
     })
   })
 })
 
-test('use helmet', t => {
+test('use helmet', (t, done) => {
   t.plan(3)
 
   const instance = fastify()
@@ -90,21 +91,22 @@ test('use helmet', t => {
   })
 
   instance.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
-    t.teardown(instance.server.close.bind(instance.server))
+    t.after(() => instance.server.close())
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + instance.server.address().port
     }, (err, response) => {
-      t.error(err)
-      t.ok(response.headers['x-xss-protection'])
+      t.assert.ifError(err)
+      t.assert.ok(response.headers['x-xss-protection'])
+      done()
     })
   })
 })
 
-test('use helmet and cors', t => {
+test('use helmet and cors', (t, done) => {
   t.plan(4)
 
   const instance = fastify()
@@ -119,22 +121,23 @@ test('use helmet and cors', t => {
   })
 
   instance.listen({ port: 0 }, err => {
-    t.error(err)
+    t.assert.ifError(err)
 
-    t.teardown(instance.server.close.bind(instance.server))
+    t.after(() => instance.server.close())
 
     sget({
       method: 'GET',
       url: 'http://localhost:' + instance.server.address().port
     }, (err, response) => {
-      t.error(err)
-      t.ok(response.headers['x-xss-protection'])
-      t.equal(response.headers['access-control-allow-origin'], '*')
+      t.assert.ifError(err)
+      t.assert.ok(response.headers['x-xss-protection'])
+      t.assert.strictEqual(response.headers['access-control-allow-origin'], '*')
+      done()
     })
   })
 })
 
-test('middlewares with prefix', t => {
+test('middlewares with prefix', (t, done) => {
   t.plan(5)
 
   const instance = fastify()
@@ -178,82 +181,87 @@ test('middlewares with prefix', t => {
   instance.get('/prefix/inner', handler)
 
   instance.listen({ port: 0 }, err => {
-    t.error(err)
-    t.teardown(instance.server.close.bind(instance.server))
+    t.assert.ifError(err)
+    t.after(() => instance.server.close())
 
-    t.test('/', t => {
+    t.test('/', (t, d) => {
       t.plan(2)
       sget({
         method: 'GET',
         url: 'http://localhost:' + instance.server.address().port + '/',
         json: true
       }, (err, _response, body) => {
-        t.error(err)
-        t.same(body, {
+        t.assert.ifError(err)
+        t.assert.deepStrictEqual(body, {
           global: true,
           global2: true,
           root: true
         })
+        d()
       })
     })
 
-    t.test('/prefix', t => {
+    t.test('/prefix', (t, d) => {
       t.plan(2)
       sget({
         method: 'GET',
         url: 'http://localhost:' + instance.server.address().port + '/prefix',
         json: true
       }, (err, _response, body) => {
-        t.error(err)
-        t.same(body, {
+        t.assert.ifError(err)
+        t.assert.deepStrictEqual(body, {
           prefixed: true,
           global: true,
           global2: true,
           root: true,
           slashed: true
         })
+        d()
       })
     })
 
-    t.test('/prefix/', t => {
+    t.test('/prefix/', (t, d) => {
       t.plan(2)
       sget({
         method: 'GET',
         url: 'http://localhost:' + instance.server.address().port + '/prefix/',
         json: true
       }, (err, _response, body) => {
-        t.error(err)
-        t.same(body, {
+        t.assert.ifError(err)
+        t.assert.deepStrictEqual(body, {
           prefixed: true,
           slashed: true,
           global: true,
           global2: true,
           root: true
         })
+        d()
       })
     })
 
-    t.test('/prefix/inner', t => {
+    t.test('/prefix/inner', (t, d) => {
       t.plan(2)
       sget({
         method: 'GET',
         url: 'http://localhost:' + instance.server.address().port + '/prefix/inner',
         json: true
       }, (err, _response, body) => {
-        t.error(err)
-        t.same(body, {
+        t.assert.ifError(err)
+        t.assert.deepStrictEqual(body, {
           prefixed: true,
           slashed: true,
           global: true,
           global2: true,
           root: true
         })
+        d()
+        done()
       })
     })
   })
 })
 
-test('res.end should block middleware execution', t => {
+test('res.end should block middleware execution', (t, done) => {
   t.plan(4)
 
   const instance = fastify()
@@ -264,49 +272,50 @@ test('res.end should block middleware execution', t => {
       })
 
       instance.use(function () {
-        t.fail('we should not be here')
+        t.assert.fail('we should not be here')
       })
     })
 
   instance.addHook('onRequest', (_req, _res, next) => {
-    t.ok('called')
+    t.assert.ok('called')
     next()
   })
 
   instance.addHook('preHandler', (_req, _reply, _next) => {
-    t.fail('this should not be called')
+    t.assert.fail('this should not be called')
   })
 
   instance.addHook('onSend', (_req, _reply, _payload, _next) => {
-    t.fail('this should not be called')
+    t.assert.fail('this should not be called')
   })
 
   instance.addHook('onResponse', (_request, _reply, next) => {
-    t.ok('called')
+    t.assert.ok('called')
     next()
   })
 
   instance.get('/', function () {
-    t.fail('we should no be here')
+    t.assert.fail('we should no be here')
   })
 
   instance.inject({
     url: '/',
     method: 'GET'
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.equal(res.payload, 'hello')
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, 'hello')
+    done()
   })
 })
 
-test('middlewares should be able to respond with a stream', t => {
+test('middlewares should be able to respond with a stream', (t, done) => {
   t.plan(4)
 
   const instance = fastify()
 
   instance.addHook('onRequest', (_req, _res, next) => {
-    t.ok('called')
+    t.assert.ok('called')
     next()
   })
 
@@ -319,44 +328,45 @@ test('middlewares should be able to respond with a stream', t => {
       })
 
       instance.use(function () {
-        t.fail('we should not be here')
+        t.assert.fail('we should not be here')
       })
     })
 
   instance.addHook('preHandler', () => {
-    t.fail('this should not be called')
+    t.assert.fail('this should not be called')
   })
 
   instance.addHook('onSend', () => {
-    t.fail('this should not be called')
+    t.assert.fail('this should not be called')
   })
 
   instance.addHook('onResponse', (_request, _reply, next) => {
-    t.ok('called')
+    t.assert.ok('called')
     next()
   })
 
   instance.get('/', function () {
-    t.fail('we should no be here')
+    t.assert.fail('we should no be here')
   })
 
   instance.inject({
     url: '/',
     method: 'GET'
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    done()
   })
 })
 
-test('Use a middleware inside a plugin after an encapsulated plugin', t => {
+test('Use a middleware inside a plugin after an encapsulated plugin', (t, done) => {
   t.plan(4)
   const f = fastify()
   f.register(middiePlugin)
 
   f.register(function (instance, _opts, next) {
     instance.use(function (_req, _res, next) {
-      t.ok('first middleware called')
+      t.assert.ok('first middleware called')
       next()
     })
 
@@ -377,27 +387,28 @@ test('Use a middleware inside a plugin after an encapsulated plugin', t => {
   }))
 
   f.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    done()
   })
 })
 
-test('middlewares should run in the order in which they are defined', t => {
+test('middlewares should run in the order in which they are defined', (t, done) => {
   t.plan(9)
   const f = fastify()
   f.register(middiePlugin)
 
   f.register(fp(function (instance, _opts, next) {
     instance.use(function (req, _res, next) {
-      t.equal(req.previous, undefined)
+      t.assert.strictEqual(req.previous, undefined)
       req.previous = 1
       next()
     })
 
     instance.register(fp(function (i, _opts, next) {
       i.use(function (req, _res, next) {
-        t.equal(req.previous, 2)
+        t.assert.strictEqual(req.previous, 2)
         req.previous = 3
         next()
       })
@@ -405,7 +416,7 @@ test('middlewares should run in the order in which they are defined', t => {
     }))
 
     instance.use(function (req, _res, next) {
-      t.equal(req.previous, 1)
+      t.assert.strictEqual(req.previous, 1)
       req.previous = 2
       next()
     })
@@ -415,19 +426,19 @@ test('middlewares should run in the order in which they are defined', t => {
 
   f.register(function (instance, _opts, next) {
     instance.use(function (req, _res, next) {
-      t.equal(req.previous, 3)
+      t.assert.strictEqual(req.previous, 3)
       req.previous = 4
       next()
     })
 
     instance.get('/', function (request, reply) {
-      t.equal(request.raw.previous, 5)
+      t.assert.strictEqual(request.raw.previous, 5)
       reply.send({ hello: 'world' })
     })
 
     instance.register(fp(function (i, _opts, next) {
       i.use(function (req, _res, next) {
-        t.equal(req.previous, 4)
+        t.assert.strictEqual(req.previous, 4)
         req.previous = 5
         next()
       })
@@ -438,8 +449,9 @@ test('middlewares should run in the order in which they are defined', t => {
   })
 
   f.inject('/', (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.payload), { hello: 'world' })
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.payload), { hello: 'world' })
+    done()
   })
 })

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -137,8 +137,8 @@ test('use helmet and cors', (t, done) => {
   })
 })
 
-test('middlewares with prefix', (t, done) => {
-  t.plan(5)
+test('middlewares with prefix', async t => {
+  t.plan(4)
 
   const instance = fastify()
   instance.register(middiePlugin)
@@ -180,83 +180,80 @@ test('middlewares with prefix', (t, done) => {
   instance.get('/prefix/', handler)
   instance.get('/prefix/inner', handler)
 
-  instance.listen({ port: 0 }, err => {
-    t.assert.ifError(err)
-    t.after(() => instance.server.close())
+  const address = await instance.listen({ port: 0 })
+  t.after(() => instance.server.close())
 
-    t.test('/', (t, d) => {
-      t.plan(2)
-      sget({
-        method: 'GET',
-        url: 'http://localhost:' + instance.server.address().port + '/',
-        json: true
-      }, (err, _response, body) => {
-        t.assert.ifError(err)
-        t.assert.deepStrictEqual(body, {
-          global: true,
-          global2: true,
-          root: true
-        })
-        d()
+  await t.test('/', (t, done) => {
+    t.plan(2)
+    sget({
+      method: 'GET',
+      url: address + '/',
+      json: true
+    }, (err, _response, body) => {
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(body, {
+        global: true,
+        global2: true,
+        root: true
       })
+      done()
     })
+  })
 
-    t.test('/prefix', (t, d) => {
-      t.plan(2)
-      sget({
-        method: 'GET',
-        url: 'http://localhost:' + instance.server.address().port + '/prefix',
-        json: true
-      }, (err, _response, body) => {
-        t.assert.ifError(err)
-        t.assert.deepStrictEqual(body, {
-          prefixed: true,
-          global: true,
-          global2: true,
-          root: true,
-          slashed: true
-        })
-        d()
+  await t.test('/prefix', (t, done) => {
+    t.plan(2)
+    sget({
+      method: 'GET',
+      url: address + '/prefix',
+      json: true
+    }, (err, _response, body) => {
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(body, {
+        prefixed: true,
+        global: true,
+        global2: true,
+        root: true,
+        slashed: true
       })
+      done()
     })
+  })
 
-    t.test('/prefix/', (t, d) => {
-      t.plan(2)
-      sget({
-        method: 'GET',
-        url: 'http://localhost:' + instance.server.address().port + '/prefix/',
-        json: true
-      }, (err, _response, body) => {
-        t.assert.ifError(err)
-        t.assert.deepStrictEqual(body, {
-          prefixed: true,
-          slashed: true,
-          global: true,
-          global2: true,
-          root: true
-        })
-        d()
+  await t.test('/prefix/', (t, done) => {
+    t.plan(2)
+    sget({
+      method: 'GET',
+      url: address + '/prefix/',
+      json: true
+    }, (err, _response, body) => {
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(body, {
+        prefixed: true,
+        slashed: true,
+        global: true,
+        global2: true,
+        root: true
       })
+      done()
     })
+  })
 
-    t.test('/prefix/inner', (t, d) => {
-      t.plan(2)
-      sget({
-        method: 'GET',
-        url: 'http://localhost:' + instance.server.address().port + '/prefix/inner',
-        json: true
-      }, (err, _response, body) => {
-        t.assert.ifError(err)
-        t.assert.deepStrictEqual(body, {
-          prefixed: true,
-          slashed: true,
-          global: true,
-          global2: true,
-          root: true
-        })
-        d()
-        done()
+  await t.test('/prefix/inner', (t, done) => {
+    t.plan(2)
+    sget({
+      method: 'GET',
+      url: address + '/prefix/inner',
+      json: true
+    }, (err, _response, body) => {
+      t.assert.ifError(err)
+      t.assert.deepStrictEqual(body, {
+        prefixed: true,
+        slashed: true,
+        global: true,
+        global2: true,
+        root: true
       })
+      done()
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hi,

The goal of this PR is migrate the tests from Tap to Node test runner, following what's been said in the issue https://github.com/fastify/fastify/issues/5555

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

