### PR TITLE
fix: decode paths before matching

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2,7 +2,7 @@
 
 const reusify = require('reusify')
 const { pathToRegexp } = require('path-to-regexp')
-const url_sanitizer_1 = require("find-my-way/lib/url-sanitizer");
+const urlSanitizer = require("find-my-way/lib/url-sanitizer");
 
 function middie (complete) {
   const middlewares = []
@@ -99,7 +99,7 @@ function middie (complete) {
         const fn = middleware.fn
         const regexp = middleware.regexp
         if (regexp) {
-          const decodedUrl = url_sanitizer_1.safeDecodeURI(url).path;
+          const decodedUrl = urlSanitizer.safeDecodeURI(url).path;
           const result = regexp.exec(decodedUrl)
           if (result) {
             req.url = req.url.replace(result[0], '')

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2,7 +2,7 @@
 
 const reusify = require('reusify')
 const { pathToRegexp } = require('path-to-regexp')
-const urlSanitizer = require("find-my-way/lib/url-sanitizer");
+const urlSanitizer = require('find-my-way/lib/url-sanitizer')
 
 function middie (complete) {
   const middlewares = []
@@ -99,7 +99,7 @@ function middie (complete) {
         const fn = middleware.fn
         const regexp = middleware.regexp
         if (regexp) {
-          const decodedUrl = urlSanitizer.safeDecodeURI(url).path;
+          const decodedUrl = urlSanitizer.safeDecodeURI(url).path
           const result = regexp.exec(decodedUrl)
           if (result) {
             req.url = req.url.replace(result[0], '')

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2,7 +2,7 @@
 
 const reusify = require('reusify')
 const { pathToRegexp } = require('path-to-regexp')
-const urlSanitizer = require('find-my-way/lib/url-sanitizer')
+const FindMyWay = require('find-my-way')
 
 function middie (complete) {
   const middlewares = []
@@ -99,7 +99,7 @@ function middie (complete) {
         const fn = middleware.fn
         const regexp = middleware.regexp
         if (regexp) {
-          const decodedUrl = urlSanitizer.safeDecodeURI(url).path
+          const decodedUrl = FindMyWay.sanitizeUrlPath(url)
           const result = regexp.exec(decodedUrl)
           if (result) {
             req.url = req.url.replace(result[0], '')

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2,6 +2,7 @@
 
 const reusify = require('reusify')
 const { pathToRegexp } = require('path-to-regexp')
+const url_sanitizer_1 = require("find-my-way/lib/url-sanitizer");
 
 function middie (complete) {
   const middlewares = []
@@ -98,7 +99,8 @@ function middie (complete) {
         const fn = middleware.fn
         const regexp = middleware.regexp
         if (regexp) {
-          const result = regexp.exec(url)
+          const decodedUrl = url_sanitizer_1.safeDecodeURI(url).path;
+          const result = regexp.exec(decodedUrl)
           if (result) {
             req.url = req.url.replace(result[0], '')
             if (req.url[0] !== '/') {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@fastify/error": "^4.0.0",
     "fastify-plugin": "^5.0.0",
-    "find-my-way": "^9.3.0",
+    "find-my-way": "^9.4.0",
     "path-to-regexp": "^8.1.0",
     "reusify": "^1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@fastify/error": "^4.0.0",
     "fastify-plugin": "^5.0.0",
+    "find-my-way": "^9.3.0",
     "path-to-regexp": "^8.1.0",
     "reusify": "^1.0.4"
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fix on the NestJS side https://github.com/nestjs/nest/pull/16135

```ts
instance.use('/admin', function (req, _res, next) {
  // check headers here to ensure caller is allowed to access this endpoint
  // <auth logic>
  next()
})
```

if someone calls `your-api:3000/%61dmin`, no middleware will be triggered, even though the `/admin` endpoint (handler) would be executed (as `find-my-way` decode URLs before matching routes)

credit for reporting this issue goes to Hacktron AI

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
