### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ It is possible to change the Fastify hook that the middleware will be attached t
 
 To change the hook, pass a `hook` option like so:
 
-*Note you can access `req.body` from the `preParsing`, `onError`, `preSerialization`, and `onSend` lifecycle steps. Take a look at the [Lifecycle](https://www.fastify.dev/docs/latest/Reference/Lifecycle/) documentation page to see the order of the steps.*
+*Note you can access `req.body` from the `preParsing`, `onError`, `preSerialization`, and `onSend` lifecycle steps. Take a look at the [Lifecycle](https://fastify.dev/docs/latest/Reference/Lifecycle/) documentation page to see the order of the steps.*
 
 ```js
 const fastify = require('fastify')()
@@ -261,7 +261,7 @@ This project is kindly sponsored by:
 - [nearForm](https://nearform.com)
 
 Past sponsors:
-- [LetzDoIt](https://www.letzdoitapp.com/)
+- LetzDoIt
 
 ## License
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71